### PR TITLE
fix: skip passphrase missing error

### DIFF
--- a/pkg/streamer/ssh/ssh.go
+++ b/pkg/streamer/ssh/ssh.go
@@ -532,6 +532,11 @@ func (m *Streamer) GetConfig(ctx context.Context) (*ssh.ClientConfig, error) {
 			passphrase := creds.GetPassphrase()
 			if len(passphrase) > 0 {
 				signer, err = ssh.ParsePrivateKeyWithPassphrase(pk, []byte(passphrase))
+			} else {
+				m.logger.Info("passphrase missing error", zap.Error(err))
+				// suppress passphrase protected error
+				// maybe another method will work
+				err = nil
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
Do not exit if given key is passphrased and we don't know passphrase