### PR TITLE
fix: make gnetcli_server's authenticate() method work with unix socket clients

### DIFF
--- a/cmd/gnetcli_server/server.go
+++ b/cmd/gnetcli_server/server.go
@@ -73,7 +73,8 @@ func main() {
 	logger = zap.Must(logConfig.Build())
 
 	if len(cfg.UnixSocket) > 0 {
-		logger.Debug("init unix socket", zap.String("path", cfg.UnixSocket))
+		// log level and "init unix socket", "path" is used in gnetcli_adapter
+		logger.Warn("init unix socket", zap.String("path", cfg.UnixSocket))
 		unixSocketLn, err := newUnixSocket(cfg.UnixSocket)
 		if err != nil {
 			logger.Panic("unix socket error", zap.Error(err))
@@ -90,6 +91,7 @@ func main() {
 		if err != nil {
 			logger.Panic("tcp socket error", zap.Error(err))
 		}
+		// log level and "init tcp socket", "address" is used in gnetcli_adapter
 		logger.Warn("init tcp socket", zap.String("address", tcpSocketLn.Addr().String()))
 		grpcListeners = append(grpcListeners, tcpSocketLn)
 		if cfg.HttpListen != "" {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -196,7 +196,7 @@ func (m *Server) makeDevice(hostname string, params hostParams, add func(op gtra
 func (m *Server) ExecChat(stream pb.Gnetcli_ExecChatServer) error {
 	authData, ok := getAuthFromContext(stream.Context())
 	if !ok {
-		return errors.New("empty auth")
+		return errors.New("empty auth in exec chat")
 	}
 	logger := zap.New(m.log.Core()).With(zap.String("cmd_login", authData.GetUser()))
 	logger.Info("start chat")


### PR DESCRIPTION
authenticate() method broken for unix-socket clients due to extractIP()

Changes:

  * extractIP() -> extractPeerAddr() returns more generic net.Addr
  * authenticate() does return error just because we cant create a logger
  * ExecChat() returns an unique error if authenticate() is skipped
  * Bump log level for "init unix socket" log entry to Warn