### PR TITLE
fix: switch control connection to stdio forward

### DIFF
--- a/pkg/server/devuath.go
+++ b/pkg/server/devuath.go
@@ -33,12 +33,16 @@ func (m authApp) GetHostParams(host string, params *pb.HostParams) (hostParams, 
 	} else if m.config.SshConfig {
 		proxyJump = ssh_config.Get(host, "ProxyJump")
 		controlPath = ssh_config.Get(host, "ControlPath")
+		realHost := ssh_config.Get(host, "Hostname")
+		if len(realHost) > 0 {
+			host = realHost
+		}
 	}
 	creds, err := m.Get(host)
 	if err != nil {
 		return hostParams{}, err
 	}
-	res := NewHostParams(creds, params.GetDevice(), ip, port, proxyJump, controlPath)
+	res := NewHostParams(creds, params.GetDevice(), ip, port, proxyJump, controlPath, host)
 	return res, nil
 }
 

--- a/pkg/streamer/ssh/ssh_control_file.go
+++ b/pkg/streamer/ssh/ssh_control_file.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -23,31 +24,78 @@ func resolveHomeDir(path string) string {
 	return path
 }
 
-func dialControlMasterConf(ctx context.Context, controlFile string, endpoint Endpoint, conf *ssh.ClientConfig, logger *zap.Logger) (*ssh.Client, error) {
+func dialControlMasterConf(_ context.Context, controlFile string, endpoint Endpoint, conf *ssh.ClientConfig, logger *zap.Logger) (*ControlConn, error) {
 	params := tssh.NewSshParam(endpoint.Host, strconv.Itoa(endpoint.Port), conf.User, nil)
 	expandedPath, err := tssh.ExpandTokens(controlFile, params, "%CdhijkLlnpru")
 	if err != nil {
 		return nil, err
 	}
 	resolvedPath := resolveHomeDir(expandedPath)
-	logger.Debug("dialControlMaster", zap.String("path", resolvedPath))
-	conn, err := dialControlMaster(ctx, resolvedPath)
-	return conn, err
+	logger.Debug("open control file", zap.String("path", resolvedPath))
+	c, err := OpenControl(resolvedPath)
+	if err != nil {
+		return nil, err
+	}
+	return c, err
 }
 
-func dialControlMaster(_ context.Context, filePath string) (*ssh.Client, error) {
+type ControlConn struct {
+	conn *net.UnixConn
+}
+
+// OpenControl opens a connection to the control socket.
+func OpenControl(filePath string) (*ControlConn, error) {
 	conn, err := net.Dial("unix", filePath)
 	if err != nil {
 		return nil, err
 	}
+	uConn := conn.(*net.UnixConn)
+	return &ControlConn{conn: uConn}, nil
+}
 
-	ncc, chans, reqs, err := tssh.NewControlClientConn(conn)
+func (m *ControlConn) Close() error {
+	return m.conn.Close()
+}
+
+// NewSession implements sshClient interface.
+func (m *ControlConn) NewSession() (*ssh.Session, error) {
+	return nil, fmt.Errorf("not supported")
+}
+
+// DialControlStdioForward establishes tunnel over an ControlMaster socket in Stdio Forward mode.
+func (m *ControlConn) DialControlStdioForward(host string, port int) (*tssh.ConnectionForward, error) {
+	// Stdio forwarding MUX_C_NEW_STDIO_FWD
+	forward, err := tssh.NewControlStdioForward(m.conn, host, port)
 	if err != nil {
 		return nil, err
 	}
 
-	client := ssh.NewClient(ncc, chans, reqs)
-	return client, nil
+	return forward, nil
+}
+
+// DialControlMasterForward establishes tunnel over an ControlMaster socket in Proxy mode.
+func (m *ControlConn) DialControlMasterForward() (ssh.Conn, <-chan ssh.NewChannel, <-chan *ssh.Request, error) {
+	// Proxy mode, MUX_C_PROXY.
+	//
+	// While this mode provides all the benefits of SSH it comes with a huge problem, which makes this mode useless in some cases.
+	// SSHD contains a bug or feature. If you are using NewControlClientConn() (proxy mode, MUX_C_PROXY)
+	// and trying to connect to unreachable host this will happen:
+	// client negotiates proxy request
+	// client opens direct-tcpip channel to unreachable host
+	// server trying to connect to unreachable host (channel is not created at this point)
+	// client closes file descriptor (because of timeout)
+	// server tries to close channel:
+	//   debug2: channel 6: send_close2
+	//   chan_send_close2: channel 6: no remote_id
+	//   debug3: mux_client_read_packet_timeout: read header failed: Broken pipe
+	//   debug2: Control master terminated unexpectedly
+	// server closes ssh-connection because of this unexpected error
+	conn, ch, ch2, err := tssh.NewControlClientConn(m.conn)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return conn, ch, ch2, err
 }
 
 func init() {


### PR DESCRIPTION
SSHD contains a bug or feature. If you are using NewControlClientConn() (proxy mode, MUX_C_PROXY) and trying to connect to unreachable host this will happen:
```
client negotiates proxy request
client opens direct-tcpip channel to unreachable host
server trying to connect to unreachable host (channel is not created at this point)
client closes file descriptor (because of timeout)
server tries to close channel:
   debug2: channel 6: send_close2
   chan_send_close2: channel 6: no remote_id
   debug3: mux_client_read_packet_timeout: read header failed: Broken pipe
   debug2: Control master terminated unexpectedly
 server closes ssh-connection because of this unexpected error
```