### PR TITLE
feat: add default read and command timeouts to gnetcli server configuration.

### DIFF
--- a/cmd/gnetcli_server/server.go
+++ b/cmd/gnetcli_server/server.go
@@ -141,6 +141,12 @@ func main() {
 	grpcServer := grpc.NewServer(opts...)
 
 	serverOpts := []server.Option{server.WithLogger(logger)}
+	if cfg.DefaultReadTimeout > 0 {
+		serverOpts = append(serverOpts, server.WithDefaultReadTimeout(cfg.DefaultReadTimeout))
+	}
+	if cfg.DefaultCmdTimeout > 0 {
+		serverOpts = append(serverOpts, server.WithDefaultCmdTimeout(cfg.DefaultCmdTimeout))
+	}
 	devAuthApp := server.NewAuthApp(cfg.DevAuth, logger)
 	s, err := server.New(devAuthApp, cfg.DevConf, serverOpts...)
 	if err != nil {

--- a/pkg/server/conf.go
+++ b/pkg/server/conf.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"time"
 
 	"github.com/heetch/confita"
 	"github.com/heetch/confita/backend"
@@ -22,19 +23,21 @@ type Config struct {
 	Listen     string    `config:"port,description=Listen address" yaml:"port"`
 	HttpListen string    `config:"http_port,description=Http listen address" yaml:"http_port"`
 	// FIXME: Dev* in DevAuth, drop it
-	DevLogin    string        `config:"dev-login,description=Default device login" yaml:"dev_login"`
-	DevPass     string        `config:"dev-pass,description=Default device password" yaml:"dev_pass"`
-	DevUseAgent bool          `config:"dev-use-agent" yaml:"dev_use_agent"`
-	DevAuth     authAppConfig `yaml:"dev_auth"`
-	ConfFile    string        `config:"conf-file,description=Path to config file. '-' for stdin"`
-	DevConf     string        `config:"dev-conf,Path to yaml with device types" yaml:"dev_conf"`
-	Tls         bool          `config:"tls,description=Connection uses TLS if true, else plain TCP" yaml:"tls"`
-	CertFile    string        `config:"cert-file,description=The TLS cert file" yaml:"cert_file"`
-	KeyFile     string        `config:"key-file,description=The TLS key file" yaml:"key_file"`
-	BasicAuth   string        `config:"basic-auth,description=Authenticate client using Basic auth" yaml:"basic_auth"`
-	DisableTcp  bool          `config:"disable_tcp,description=Disable TCP listener" yaml:"disable_tcp"`
-	UnixSocket  string        `config:"unix-socket,description=Unix socket path" yaml:"unix_socket"`
-	Debug       bool          `config:"debug,short=d,description=Set debug log level"`
+	DevLogin           string        `config:"dev-login,description=Default device login" yaml:"dev_login"`
+	DevPass            string        `config:"dev-pass,description=Default device password" yaml:"dev_pass"`
+	DevUseAgent        bool          `config:"dev-use-agent" yaml:"dev_use_agent"`
+	DevAuth            authAppConfig `yaml:"dev_auth"`
+	ConfFile           string        `config:"conf-file,description=Path to config file. '-' for stdin"`
+	DevConf            string        `config:"dev-conf,Path to yaml with device types" yaml:"dev_conf"`
+	Tls                bool          `config:"tls,description=Connection uses TLS if true, else plain TCP" yaml:"tls"`
+	CertFile           string        `config:"cert-file,description=The TLS cert file" yaml:"cert_file"`
+	KeyFile            string        `config:"key-file,description=The TLS key file" yaml:"key_file"`
+	BasicAuth          string        `config:"basic-auth,description=Authenticate client using Basic auth" yaml:"basic_auth"`
+	DisableTcp         bool          `config:"disable_tcp,description=Disable TCP listener" yaml:"disable_tcp"`
+	UnixSocket         string        `config:"unix-socket,description=Unix socket path" yaml:"unix_socket"`
+	Debug              bool          `config:"debug,short=d,description=Set debug log level"`
+	DefaultReadTimeout time.Duration `config:"default-read-timeout,description=Default read timeout"`
+	DefaultCmdTimeout  time.Duration `config:"default-cmd-timeout,description=Default command timeout"`
 }
 
 type LogConfig struct {

--- a/pkg/server/conf.go
+++ b/pkg/server/conf.go
@@ -36,8 +36,8 @@ type Config struct {
 	DisableTcp         bool          `config:"disable_tcp,description=Disable TCP listener" yaml:"disable_tcp"`
 	UnixSocket         string        `config:"unix-socket,description=Unix socket path" yaml:"unix_socket"`
 	Debug              bool          `config:"debug,short=d,description=Set debug log level"`
-	DefaultReadTimeout time.Duration `config:"default-read-timeout,description=Default read timeout"`
-	DefaultCmdTimeout  time.Duration `config:"default-cmd-timeout,description=Default command timeout"`
+	DefaultReadTimeout time.Duration `config:"default-read-timeout,description=Default read timeout" yaml:"default_read_timeout"`
+	DefaultCmdTimeout  time.Duration `config:"default-cmd-timeout,description=Default command timeout" yaml:"default_cmd_timeout"`
 }
 
 type LogConfig struct {


### PR DESCRIPTION
 Enable configuring the default read and command timeouts via the gnetcli server configuration.

For example, add the following to your context:
```yaml
fetcher:
    default:
        adapter: gnetcli
        params:
          server_conf: |-
            default_read_timeout: 30s
```