### PR TITLE
cisco ios: support ip ssh pubkey prompt conf-ssh-pubkey

### DIFF
--- a/pkg/device/cisco/ciscoios.go
+++ b/pkg/device/cisco/ciscoios.go
@@ -13,7 +13,7 @@ import (
 const (
 	loginExpression    = `.*Username:\s?$`
 	questionExpression = `\n(?P<question>.*Continue\? \[Y/N\]:)$`
-	promptExpression   = `(?P<prompt>[\w\-.:/]+(\(config(-\w+)*\))?)(>|#)$`
+	promptExpression   = `(?P<prompt>[\w\-.:/]+(\(conf(ig)?(-\w+)*\))?)(>|#)$`
 	errorExpression    = `(` +
 		`\r\n% Invalid input detected at '\^' marker.\r\n` +
 		`|^\r? +\^\n(% )?Invalid [\w ()]+ at '\^' marker\.` +

--- a/pkg/device/cisco/ciscoios_test.go
+++ b/pkg/device/cisco/ciscoios_test.go
@@ -28,6 +28,7 @@ func TestPrompt(t *testing.T) {
 		[]byte("\r\nhost-s2.abc.def(config-archive-log-cfg)#"),
 		[]byte("\r\nhost-s2:abc.def(config-archive-log-cfg)#"),
 		[]byte("\r\nhost-s2/abc.def(config-archive-log-cfg)#"),
+		[]byte("\r\nhost-s2(conf-ssh-pubkey)#"),
 	}
 	testutils.ExprTester(t, errorCases, promptExpression)
 }


### PR DESCRIPTION
Current prompt match was broken after ip ssh pubkey-chain

cisco-switch99#conf t
Enter configuration commands, one per line.  End with CNTL/Z.

cisco-switch9(config)#ip ssh pubkey-chain
cisco-switch9(conf-ssh-pubkey)#