### PR TITLE
update non system view prompt recognition to be the same

### DIFF
--- a/pkg/device/huawei/huawei.go
+++ b/pkg/device/huawei/huawei.go
@@ -17,7 +17,7 @@ import (
 const (
 	loginExpression    = `.*Username:$`
 	questionExpression = `(?P<question>.*Continue\? \[Y/N\]:)$`
-	promptExpression   = `(\r\n|^)(?P<prompt>(<[/\w\-\.:]+>|\[[~*]?[/\w\-\.:]+\]))$`
+	promptExpression   = `(\r\n|^)(?P<prompt>(<[/\w\-.:]+>|\[[~*]?[/\w\-.:]+\]))$`
 	errorExpression    = `(` +
 		`\^\r\nError: (?P<error>.+) at '\^' position\.` +
 		`|Error: You do not have permission to run the command or the command is incomplete` +

--- a/pkg/device/huawei/huawei.go
+++ b/pkg/device/huawei/huawei.go
@@ -17,7 +17,7 @@ import (
 const (
 	loginExpression    = `.*Username:$`
 	questionExpression = `(?P<question>.*Continue\? \[Y/N\]:)$`
-	promptExpression   = `(\r\n|^)(?P<prompt>(<[\w\-]+>|\[[~*]?[/\w\-.:]+\]))$`
+	promptExpression   = `(\r\n|^)(?P<prompt>(<[/\w\-.:]+>|\[[~*]?[/\w\-.:]+\]))$`
 	errorExpression    = `(` +
 		`\^\r\nError: (?P<error>.+) at '\^' position\.` +
 		`|Error: You do not have permission to run the command or the command is incomplete` +

--- a/pkg/device/huawei/huawei.go
+++ b/pkg/device/huawei/huawei.go
@@ -17,7 +17,7 @@ import (
 const (
 	loginExpression    = `.*Username:$`
 	questionExpression = `(?P<question>.*Continue\? \[Y/N\]:)$`
-	promptExpression   = `(\r\n|^)(?P<prompt>(<[/\w\-.:]+>|\[[~*]?[/\w\-.:]+\]))$`
+	promptExpression   = `(\r\n|^)(?P<prompt>(<[/\w\-\.:]+>|\[[~*]?[/\w\-\.:]+\]))$`
 	errorExpression    = `(` +
 		`\^\r\nError: (?P<error>.+) at '\^' position\.` +
 		`|Error: You do not have permission to run the command or the command is incomplete` +

--- a/pkg/device/huawei/huawei_test.go
+++ b/pkg/device/huawei/huawei_test.go
@@ -31,6 +31,7 @@ func TestHuaweiPrompt(t *testing.T) {
 		[]byte("[~host-auto-mmm-100GE3/3/3.111]"),
 		[]byte("<2134.aaa.bb.c-12.k1>"),
 		[]byte("<2134.aaa/bb.c-12.k1>"),
+		[]byte("<2134.aaa:bb.c-12.k1>"),
 	}
 	testutils.ExprTester(t, errorCases, promptExpression)
 }

--- a/pkg/device/huawei/huawei_test.go
+++ b/pkg/device/huawei/huawei_test.go
@@ -29,6 +29,7 @@ func TestHuaweiPrompt(t *testing.T) {
 		[]byte("\r\n[~hostname-1-100GE11/0/25]"),
 		[]byte("[*host-100GE1/1/1:1]"),
 		[]byte("[~host-auto-mmm-100GE3/3/3.111]"),
+		[]byte("<2134.aaa.bb.c-12.k1>"),
 	}
 	testutils.ExprTester(t, errorCases, promptExpression)
 }

--- a/pkg/device/huawei/huawei_test.go
+++ b/pkg/device/huawei/huawei_test.go
@@ -30,6 +30,7 @@ func TestHuaweiPrompt(t *testing.T) {
 		[]byte("[*host-100GE1/1/1:1]"),
 		[]byte("[~host-auto-mmm-100GE3/3/3.111]"),
 		[]byte("<2134.aaa.bb.c-12.k1>"),
+		[]byte("<2134.aaa/bb.c-12.k1>"),
 	}
 	testutils.ExprTester(t, errorCases, promptExpression)
 }


### PR DESCRIPTION
Current code does not match dot system-view promt.
Updated to system-view and basic-view have same promt expressions