### PR TITLE
ciscoios: make config prompt regex more permissive

### DIFF
--- a/pkg/device/cisco/ciscoios.go
+++ b/pkg/device/cisco/ciscoios.go
@@ -13,7 +13,7 @@ import (
 const (
 	loginExpression    = `.*Username:\s?$`
 	questionExpression = `\n(?P<question>.*Continue\? \[Y/N\]:)$`
-	promptExpression   = `(?P<prompt>[\w\-.:/]+(\(conf(ig)?(-\w+)*\))?)(>|#)$`
+	promptExpression   = `(?P<prompt>[\w\-.:/]+(\(conf(ig)?(-[^)]+)*\))?)(>|#)$`
 	errorExpression    = `(` +
 		`\r\n% Invalid input detected at '\^' marker.\r\n` +
 		`|^\r? +\^\n(% )?Invalid [\w ()]+ at '\^' marker\.` +

--- a/pkg/device/cisco/ciscoios_test.go
+++ b/pkg/device/cisco/ciscoios_test.go
@@ -29,6 +29,7 @@ func TestPrompt(t *testing.T) {
 		[]byte("\r\nhost-s2:abc.def(config-archive-log-cfg)#"),
 		[]byte("\r\nhost-s2/abc.def(config-archive-log-cfg)#"),
 		[]byte("\r\nhost-s2(conf-ssh-pubkey)#"),
+		[]byte("\r\nhost-s2(config-sg-tacacs+)#"),
 	}
 	testutils.ExprTester(t, errorCases, promptExpression)
 }


### PR DESCRIPTION
* allow any non-')' symbol after conf(ig)?-...
* test cisco tacacs+ config prompt
