### PR TITLE
Better performance: removed slices.Clone to decrease cpu usage in GC

### DIFF
--- a/pkg/streamer/streamer.go
+++ b/pkg/streamer/streamer.go
@@ -1,6 +1,7 @@
 /*
 Package streamer describes interface for interaction on network level.
 */
+
 package streamer
 
 import (
@@ -11,15 +12,12 @@ import (
 	"os"
 	"time"
 
-	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
-
-	"go.uber.org/multierr"
-
 	"github.com/annetutil/gnetcli/pkg/cmd"
 	"github.com/annetutil/gnetcli/pkg/credentials"
 	"github.com/annetutil/gnetcli/pkg/expr"
 	"github.com/annetutil/gnetcli/pkg/trace"
+	"go.uber.org/multierr"
+	"go.uber.org/zap"
 )
 
 var ErrNotSupported = errors.New("not supported")
@@ -244,7 +242,7 @@ func GenericReadX(ctx context.Context, inBuffer []byte, readCh chan []byte, read
 	if maxDuration == 0 && maxReadSize == 0 && regExpr == nil {
 		return nil, nil, nil, fmt.Errorf("specify maxDuration, maxReadSize or regExpr")
 	}
-	buffer := slices.Clone(inBuffer)
+	buffer := inBuffer
 	maxDurationTimeout := NewTimerWithDefault(maxDuration)
 	for {
 		readIterTimeout := NewTimerWithDefault(readTimeout)


### PR DESCRIPTION
We use gnetcli to collect metrics via NETCONF.
We noticed that our service consumes a lot of CPU.
The profile shows that most of the CPU goes to the GC.

I replaced slices.Clone to simple copy, and got dramatical decreasing CPU usage.
![image](https://github.com/user-attachments/assets/629f6e09-5c0a-4a41-81f4-3ae232b44e80)

Here is memory profile.
```
$ go tool pprof -alloc_space heap
(pprof) top
      flat  flat%   sum%        cum   cum%
 7236.70TB 93.54% 93.54%  7236.70TB 93.54%  golang.org/x/exp/slices.Clone[go.shape.[]uint8,go.shape.uint8] (inline)
   94.83TB  1.23% 94.77%    94.83TB  1.23%  regexp.(*bitState).reset
   53.46TB  0.69% 95.46%    53.46TB  0.69%  regexp/syntax.(*compiler).inst (inline)
...
(pprof) list GenericReadX
Total: 7736.22TB
ROUTINE ======================== github.com/annetutil/gnetcli/pkg/streamer.GenericReadX in external/gazelle~~go_deps~com_github_annetutil_gnetcli/pkg/streamer/streamer.go
   10.76TB  7420.81TB (flat, cum) 95.92% of Total
         .          .    242:func GenericReadX(ctx context.Context, inBuffer []byte, readCh chan []byte, readSize int, readTimeout time.Duration,
         .          .    243:	regExpr expr.Expr, maxReadSize int, maxDuration time.Duration) (*ReadXRes, []byte, []byte, error) {
         .          .    244:	if maxDuration == 0 && maxReadSize == 0 && regExpr == nil {
         .          .    245:		return nil, nil, nil, fmt.Errorf("specify maxDuration, maxReadSize or regExpr")
         .          .    246:	}
         .  7236.56TB    247:	buffer := slices.Clone(inBuffer)
         .    20.02TB    248:	maxDurationTimeout := NewTimerWithDefault(maxDuration)
```

