### PR TITLE
Update Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,12 @@ Exec a command on a device using GRPC
 TOKEN=$(echo -n "$LOGIN:$PASSWORD" | base64)
 grpcurl -H "Authorization: Basic $TOKEN" -plaintext -d '{"host": "hostname", "cmd": "dis clock", "host_params": {"device": "huawei", "credentials": {"login": "test", "password": "test"}}, "string_result": true}' localhost:50051 gnetcli.Gnetcli.Exec
 ```
+
+## Start GRPC-server via docker
+Clone the repository, build the image and run the container:
+```shell
+git clone https://github.com/annetutil/gnetcli.git
+cd gnetcli
+docker build -f image/Dockerfile -t gnetcli_server .
+docker run -p 50051:50051 gnetcli_server
+```

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.20.0 as build
+FROM golang:1.21 as build
 ADD . /build
 WORKDIR /build
 RUN CGO_ENABLED=0 go build ./cmd/gnetcli_server/
 
 FROM alpine
 ENV BASIC_AUTH="mylogin:mysecret"
-COPY --from=build /build/server /app/
-ENTRYPOINT [ "/app/server" ]
-CMD [ "-debug" ]
+COPY --from=build /build/gnetcli_server /app/
+ENTRYPOINT [ "/app/gnetcli_server" ]
+CMD [ "-debug", "-port", "0.0.0.0:50051" ]


### PR DESCRIPTION
Changes:
- Fixed typos: server->gnetcli_server
- Added command so container will start with port 50051 by default. 
- Changed go version to 1.21 because of build errors:

```
$ docker build -f image/Dockerfile -t gnetcli_server:1.20.0 .
[+] Building 15.9s (11/12)                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                            0.0s
 => => transferring dockerfile: 317B                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                                0.0s
 => [internal] load metadata for docker.io/library/golang:1.20.0                                                                                                1.9s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                               0.0s
 => => transferring context: 60B                                                                                                                                0.0s
 => [internal] load build context                                                                                                                               0.0s
 => => transferring context: 16.56kB                                                                                                                            0.0s
 => CACHED [build 1/4] FROM docker.io/library/golang:1.20.0@sha256:63c5d6404238855365d5bac79ed0564a1e1d3bcda916dfc87cfb32d027e28e1a                             0.0s
 => [stage-1 1/2] FROM docker.io/library/alpine:latest                                                                                                          0.0s
 => [build 2/4] ADD . /build                                                                                                                                    0.0s
 => [build 3/4] WORKDIR /build                                                                                                                                  0.0s
 => ERROR [build 4/4] RUN CGO_ENABLED=0 go build ./cmd/gnetcli_server/                                                                                         13.9s
------                                                                                                                                                               
 > [build 4/4] RUN CGO_ENABLED=0 go build ./cmd/gnetcli_server/:                                                                                                     
0.304 go: downloading golang.org/x/sync v0.4.0                                                                                                                       
0.305 go: downloading go.uber.org/zap v1.26.0                                                                                                                        
0.305 go: downloading github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0                                                                                              
0.308 go: downloading github.com/grpc-ecosystem/go-grpc-middleware v1.4.0                                                                                            
0.308 go: downloading google.golang.org/grpc v1.58.2
0.308 go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97
0.308 go: downloading google.golang.org/protobuf v1.31.0
0.313 go: downloading github.com/kevinburke/ssh_config v1.2.0
0.315 go: downloading github.com/mitchellh/go-homedir v1.1.0
0.333 go: downloading github.com/heetch/confita v0.0.0-20181011080120-653cbec9ecff
0.338 go: downloading github.com/pkg/errors v0.8.1
0.355 go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97
0.407 go: downloading google.golang.org/genproto v0.0.0-20231002182017-d307bd883b97
0.412 go: downloading gopkg.in/yaml.v3 v3.0.1
0.455 go: downloading go.uber.org/multierr v1.11.0
0.456 go: downloading github.com/pkg/sftp v1.13.6
0.456 go: downloading golang.org/x/crypto v0.14.0
0.508 go: downloading golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
0.509 go: downloading github.com/golang/protobuf v1.5.3
0.580 go: downloading github.com/kr/fs v0.1.0
0.718 go: downloading github.com/BurntSushi/toml v0.3.1
0.718 go: downloading gopkg.in/yaml.v2 v2.2.8
4.309 go: downloading golang.org/x/net v0.16.0
4.309 go: downloading golang.org/x/sys v0.13.0
4.771 go: downloading golang.org/x/text v0.13.0
13.75 # github.com/annetutil/gnetcli/cmd/gnetcli_server
13.75 cmd/gnetcli_server/server.go:164:11: undefined: context.AfterFunc
13.75 cmd/gnetcli_server/server.go:169:10: undefined: context.AfterFunc
13.75 note: module requires Go 1.21
------
Dockerfile:4
--------------------
   2 |     ADD . /build
   3 |     WORKDIR /build
   4 | >>> RUN CGO_ENABLED=0 go build ./cmd/gnetcli_server/
   5 |     
   6 |     FROM alpine
--------------------
ERROR: failed to solve: process "/bin/sh -c CGO_ENABLED=0 go build ./cmd/gnetcli_server/" did not complete successfully: exit code: 1
```

***

Actually when gnetcli_server starts with default params it listens on random port. Should this doc be updated https://annetutil.github.io/gnetcli/basic_usage_server/? @gescheit 
>   -port string
        Listen address (default "127.0.0.1:50051")
```
$   ~/go/bin/gnetcli_server -debug -basic-auth mylogin:mysecret
2025-07-05T14:14:20.754Z	WARN	gnetcli_server/server.go:95	init tcp socket	{"address": "127.0.0.1:31115"}
main.main
```