### PR TITLE
[aruos] Recognize WriteFlash errors

### DIFF
--- a/pkg/device/aruos/device.go
+++ b/pkg/device/aruos/device.go
@@ -7,8 +7,12 @@ import (
 )
 
 const (
-	promptExpression        = `(\r\n)?(?P<prompt>[\w\-():]+) ?# $`
-	errorExpression         = `% (Parse error|Incomplete command)`
+	promptExpression = `(\r\n)?(?P<prompt>[\w\-():]+) ?# $`
+	errorExpression  = `(` +
+		`% (Parse error|Incomplete command)` + `|` +
+		`(^|\n)WriteFlash .+` + `|` +
+		`(^|\n).+: ?WriteApFlash unsuccessful.+` +
+		`)`
 	passwordExpression      = `.*Password: $`
 	loginExpression         = `.*User: $`
 	passwordErrorExpression = `.*Login incorrect, reason code \d(\r\n)?$`

--- a/pkg/device/aruos/device_test.go
+++ b/pkg/device/aruos/device_test.go
@@ -38,3 +38,13 @@ func TestLoginFail(t *testing.T) {
 	}
 	testutils.ExprTester(t, cases, passwordErrorExpression)
 }
+
+func TestWriteFlashFail(t *testing.T) {
+	cases := [][]byte{
+		[]byte("[  504.613753] ubi1 error: ubi_open_volume: cannot open device 1, volume 0, error -16\r\nWriteFlash open /dev/env: Device or resource busysaveenv:WriteApFlash unsuccessful (flash_off=0)(size=10000)(env_data=0x04618dc8)\r\n"),
+		[]byte("WriteFlash open /dev/env: Device or resource busysaveenv:WriteApFlash unsuccessful (flash_off=0)(size=10000)(env_data=0x04618dc8)\r\n"),
+		[]byte("saveenv:WriteApFlash unsuccessful (flash_off=0)(size=10000)(env_data=0x04618dc8)\r\n"),
+		[]byte("saveenv: WriteApFlash unsuccessful (flash_off=0)(size=10000)(env_data=0x04618dc8)\r\n"),
+	}
+	testutils.ExprTester(t, cases, errorExpression)
+}


### PR DESCRIPTION
```shell
device# ip-address 192.168.1.2 255.255.255.0 192.168.1.1 192.168.1.1 company.net
[  504.613753] ubi1 error: ubi_open_volume: cannot open device 1, volume 0, error -16
WriteFlash open /dev/env: Device or resource busysaveenv:WriteApFlash unsuccessful (flash_off=0)(size=10000)(env_data=0xcc208eed)
device# 
```