### PR TITLE
nxos: add dot to prompt character class to support FQDN-style hostnames

### DIFF
--- a/pkg/device/nxos/device.go
+++ b/pkg/device/nxos/device.go
@@ -17,7 +17,7 @@ import (
 // For example 'n9k-test \r\n\rn9k-test#' - extra \r after typical \r\n.
 
 const (
-	promptExpression = `(\r\n\r)?(?P<prompt>[\w\-()+]+)# $`
+	promptExpression = `(\r\n\r)?(?P<prompt>[\w\-()+.]+)# $`
 	errorExpression  = `(% )?(Invalid|Incomplete) (command at|range at) '\^' marker.`
 	pagerExpression  = `\x1b\[7m--More--\x1b\[(27)?m`
 )

--- a/pkg/device/nxos/device_test.go
+++ b/pkg/device/nxos/device_test.go
@@ -11,6 +11,7 @@ func TestPrompt(t *testing.T) {
 		[]byte("\r\n\rn9k-9316-test# "),
 		[]byte("\r\n\rn9k-9316-test(config)# "),
 		[]byte("\r\n\rn3k-test(config-tacacs+)# "),
+		[]byte("\r\n\rrdc1_sw_rack42.spine-1-0# "),
 	}
 	testutils.ExprTester(t, cases, promptExpression)
 }


### PR DESCRIPTION
Hostnames containing dots (e.g. rdc1_sw_rack42.spine-1-0) caused the prompt regex to match only the last dot-separated segment, leaking the rest of the hostname into command output.