### PR TITLE
devconf: add any_echo feature for devices that expand commands before echoing

### DIFF
--- a/pkg/devconf/devconf.go
+++ b/pkg/devconf/devconf.go
@@ -34,6 +34,7 @@ const (
 	FeatureSpacesAfterEcho = "spaces_after_echo"
 	FeatureExtraCrEcho     = "extra_cr_echo"
 	FeatureANSIEscSeqEcho  = "ansi_esc_seq_echo"
+	FeatureAnyEcho         = "any_echo"
 )
 
 type DevConf struct {
@@ -120,6 +121,13 @@ func (m DevConf) Make() (*genericcli.GenericCLI, error) {
 			case FeatureANSIEscSeqEcho:
 				a := genericcli.WithEchoExprFn(func(c cmd.Cmd) expr.Expr {
 					return expr.NewSimpleExpr().FromPattern(fmt.Sprintf(`%s(?:\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e])+\r\n`, regexp.QuoteMeta(string(c.Value()))))
+				})
+				opts = append(opts, a)
+			case FeatureAnyEcho:
+				// Match any echoed line regardless of command expansion by the device
+				// (e.g. SONiC expands "show run" → "show running-configuration" before echoing).
+				a := genericcli.WithEchoExprFn(func(c cmd.Cmd) expr.Expr {
+					return expr.NewSimpleExpr().FromPattern(`.*(\r\n|\n)`)
 				})
 				opts = append(opts, a)
 			default:

--- a/pkg/devconf/devconf.go
+++ b/pkg/devconf/devconf.go
@@ -124,8 +124,9 @@ func (m DevConf) Make() (*genericcli.GenericCLI, error) {
 				})
 				opts = append(opts, a)
 			case FeatureAnyEcho:
-				// Match any echoed line regardless of command expansion by the device
+				// Always matches the first line following the write command, treating it as an echo command.
 				// (e.g. SONiC expands "show run" → "show running-configuration" before echoing).
+				// Usage is strongly discouraged due to potential execution flow issues.
 				a := genericcli.WithEchoExprFn(func(c cmd.Cmd) expr.Expr {
 					return expr.NewSimpleExpr().FromPattern(`.*(\r\n|\n)`)
 				})


### PR DESCRIPTION
Some devices (e.g. SONiC) expand abbreviated commands before echoing them back (e.g. `show run` → `show running-configuration`). The existing echo features all anchor on the literal command text via `regexp.QuoteMeta(c.Value())`, so they fail when the echoed line doesn't match what was sent.

Adds a new `any_echo` feature flag that uses `.*(\r\n|\n)` as the echo pattern, matching any single echoed line regardless of content.

## Usage
Add `any_echo` to the device's `features` list in the YAML config. Example:
devices:
```yaml
- name: sonic
  prompt_expression: '(\r\n|^)[\w\-\.]+# $'
  error_expression: '\r\nError: (The command is not completed|Invalid input detected at "\^" marker|Ambiguous command)\.'
  pager_expression: '--more--$'
  features:
    - any_echo
    - autocmds:
      - terminal length 0
```