### PR TITLE
Add "cfg" sub-mode Cisco promtExp 

### DIFF
--- a/pkg/device/cisco/ciscoios.go
+++ b/pkg/device/cisco/ciscoios.go
@@ -13,7 +13,7 @@ import (
 const (
 	loginExpression    = `.*Username:\s?$`
 	questionExpression = `\n(?P<question>.*Continue\? \[Y/N\]:)$`
-	promptExpression   = `(?P<prompt>[\w\-.:/]+(\((conf(ig)?|c[as]|ipsec)?(-[^)]+)*\))?)(>|#)$`
+	promptExpression   = `(?P<prompt>[\w\-.:/]+(\((conf(ig)?|c[as]|ipsec|cfg)?(-[^)]+)*\))?)(>|#)$`
 	errorExpression    = `(` +
 		`\r\n% Invalid input detected at '\^' marker.\r\n` +
 		`|^\r? +\^\n(% )?Invalid [\w ()]+ at '\^' marker\.` +

--- a/pkg/device/cisco/ciscoios_test.go
+++ b/pkg/device/cisco/ciscoios_test.go
@@ -33,6 +33,7 @@ func TestPrompt(t *testing.T) {
 		[]byte("\r\nhostname(ca-trustpoint)#"),
 		[]byte("\r\nhostname(cs-server)#"),
 		[]byte("\r\nhostname-32(ipsec-profile)#"),
+		[]byte("\r\nhostname(cfg-crypto-trans)#"),
 	}
 	testutils.ExprTester(t, errorCases, promptExpression)
 }


### PR DESCRIPTION
fix(cisco): broaden prompt regex to match transform-set sub-modes

Cisco IOS transform-set configuration command (crypto ipsec transform-set)
enter sub-mode with prompt (cfg-crypto-trans). The current regex
doesn't match this prompt, causing read timeout errors.
ex. 
hostname(config)#crypto ipsec transform-set AES256 esp-aes 256 esp-sha-hmac
hostname(cfg-crypto-trans)# 

Broadened the regex to match this parenthesized sub-mode prompt.