### PR TITLE
feat: add fortios support

### DIFF
--- a/pkg/device/fortios/device.go
+++ b/pkg/device/fortios/device.go
@@ -1,0 +1,57 @@
+/*
+Package fortios implements FortiOS CLI using genericcli.
+*/
+package fortios
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/annetutil/gnetcli/pkg/cmd"
+	"github.com/annetutil/gnetcli/pkg/device/genericcli"
+	"github.com/annetutil/gnetcli/pkg/expr"
+	"github.com/annetutil/gnetcli/pkg/streamer"
+)
+
+const (
+	questionExpression = `(?P<question>[dD]o you want to continue\? \(y/n\))\s*$`
+	promptExpression   = `(?P<prompt>[\w\-()~ ]+)[#$]\s*$`
+	errorExpression    = `(` +
+		`Command fail\.?` +
+		`|Unknown action` +
+		`|Node not found` +
+		`|Entry not found` +
+		`|Parse error` +
+		`|Incomplete command` +
+		`|Ambiguous command` +
+		`|Permission denied` +
+		`|Invalid value` +
+		`|Input is not a valid` +
+		`|failover status: unset` +
+		`|Unknown phase2` +
+		`)`
+	pagerExpression = `--\s?[Mm]ore\s?--`
+)
+
+var autoCommands = []cmd.Cmd{
+	cmd.NewCmd("config system console", cmd.WithErrorIgnore()),
+	cmd.NewCmd("set output standard", cmd.WithErrorIgnore()),
+	cmd.NewCmd("end", cmd.WithErrorIgnore()),
+}
+
+func NewDevice(connector streamer.Connector, opts ...genericcli.GenericDeviceOption) genericcli.GenericDevice {
+	cli := genericcli.MakeGenericCLI(
+		expr.NewSimpleExprLast200().FromPattern(promptExpression),
+		expr.NewSimpleExprLast200().FromPattern(errorExpression),
+		genericcli.WithPager(
+			expr.NewSimpleExprLast200().FromPattern(pagerExpression)),
+		genericcli.WithQuestion(
+			expr.NewSimpleExprLast200().FromPattern(questionExpression)),
+		genericcli.WithAutoCommands(autoCommands),
+		genericcli.WithEchoExprFn(func(c cmd.Cmd) expr.Expr {
+			return expr.NewSimpleExpr().FromPattern(fmt.Sprintf(`%s\r\r\n`, regexp.QuoteMeta(string(c.Value()))))
+		}),
+		genericcli.WithTerminalParams(400, 0),
+	)
+	return genericcli.MakeGenericDevice(cli, connector, opts...)
+}

--- a/pkg/device/fortios/device.go
+++ b/pkg/device/fortios/device.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	questionExpression = `(?P<question>[dD]o you want to continue\? \(y/n\))\s*$`
-	promptExpression   = `(?P<prompt>[\w\-()~ ]+)[#$]\s*$`
+	questionExpression = `(?P<question>[dD]o you want to continue\? \(y/n\))\s{0,1}$`
+	promptExpression   = `(?P<prompt>[\w\-()~ ]+)[#$]\s$`
 	errorExpression    = `(` +
 		`Command fail\.?` +
 		`|Unknown action` +

--- a/pkg/device/fortios/device_test.go
+++ b/pkg/device/fortios/device_test.go
@@ -13,9 +13,9 @@ func TestPrompt(t *testing.T) {
 		[]byte("\r\nForti1 # "),
 		[]byte("Forti-Gate (context) # "),
 		[]byte("F-Gate $ "),
-		[]byte("forti-fw~-01 $"),
-		[]byte("\r\n\r\nforti-fw~-01 (vdom) $"),
-		[]byte("end\r\n\r\nforti-fw~-01 (address) $"),
+		[]byte("forti-fw~-01 $ "),
+		[]byte("\r\n\r\nforti-fw~-01 (vdom) $ "),
+		[]byte("end\r\n\r\nforti-fw~-01 (address) $ "),
 	}
 	testutils.ExprTester(t, cases, promptExpression)
 }

--- a/pkg/device/fortios/device_test.go
+++ b/pkg/device/fortios/device_test.go
@@ -1,0 +1,59 @@
+package fortios
+
+import (
+	"testing"
+
+	"github.com/annetutil/gnetcli/pkg/testutils"
+)
+
+func TestPrompt(t *testing.T) {
+	cases := [][]byte{
+		[]byte("Forti1 # "),
+		[]byte("end\r\n\r\nForti1 # "),
+		[]byte("\r\nForti1 # "),
+		[]byte("Forti-Gate (context) # "),
+		[]byte("F-Gate $ "),
+		[]byte("forti-fw~-01 $"),
+		[]byte("\r\n\r\nforti-fw~-01 (vdom) $"),
+		[]byte("end\r\n\r\nforti-fw~-01 (address) $"),
+	}
+	testutils.ExprTester(t, cases, promptExpression)
+}
+
+func TestErrors(t *testing.T) {
+	cases := [][]byte{
+		[]byte("failover status: unset"),
+		[]byte("\r\ncommand parse error before 'reboot'\r\nCommand fail. Return code -61\r\n\r\n"),
+		[]byte("invalid unsigned integer value: unexist\r\n\r\nvalue parse error before 'unexist'\r\nCommand fail. Return code -651\r\n"),
+		[]byte("Unknown action\r\n\r\nForti1 (policy) # "),
+	}
+	testutils.ExprTester(t, cases, errorExpression)
+}
+
+func TestQuestion(t *testing.T) {
+	cases := [][]byte{
+		[]byte("This operation will reboot the system !\r\nDo you want to continue? (y/n)"),
+		[]byte("Do you want to continue? (y/n) "),
+		[]byte("\r\ndo you want to continue? (y/n)"),
+	}
+	testutils.ExprTester(t, cases, questionExpression)
+}
+
+func TestPager(t *testing.T) {
+	cases := [][]byte{
+		[]byte("-- More --"),
+		[]byte("--More--"),
+		[]byte("-- more --"),
+		[]byte("--more--"),
+	}
+	testutils.ExprTester(t, cases, pagerExpression)
+}
+
+func TestNotPrompt(t *testing.T) {
+	errorCases := [][]byte{
+		[]byte("config system stp"),
+		[]byte("end"),
+		[]byte("Forti1 # some-text"),
+	}
+	testutils.ExprTesterFalse(t, errorCases, promptExpression)
+}


### PR DESCRIPTION
Implemented the FortiOS driver. 
Tested on physical hardware.

I saw this part in pkg/devconf/devconf.go, but I haven't added anything there yet. I can add it if needed.
```
func InitDefaultDeviceMapping(logger *zap.Logger) map[string]func(streamer.Connector) device.Device {..}
```


I hereby agree to the terms of the CLA available at: [Link](https://yandex.ru/legal/cla/?lang=en).

