### PR TITLE
Relax Cisco pager expression

### DIFF
--- a/pkg/device/cisco/ciscoios.go
+++ b/pkg/device/cisco/ciscoios.go
@@ -28,7 +28,7 @@ const (
 		`)`
 	passwordExpression      = `.*Password:\s?$`
 	passwordErrorExpression = `\n\% Authentication failed(\r\n|\n)`
-	pagerExpression         = `\r\n --More-- $`
+	pagerExpression         = `\r\n ?--More-- $`
 )
 
 var autoCommands = []cmd.Cmd{

--- a/pkg/device/cisco/ciscoios_test.go
+++ b/pkg/device/cisco/ciscoios_test.go
@@ -65,3 +65,11 @@ func TestQuestion(t *testing.T) {
 	}
 	testutils.ExprTester(t, errorCases, questionExpression)
 }
+
+func TestPager(t *testing.T) {
+	cases := [][]byte{
+		[]byte("\r\n --More-- "),
+		[]byte("\r\n--More-- "),
+	}
+	testutils.ExprTester(t, cases, pagerExpression)
+}


### PR DESCRIPTION
Cisco CW9176I devices seem to have a bit of a different pager expression - there is no space between `\r\n` and `--More-- `:

```
read timeout error. last seen: "             Restricted Rights Legend\r\n\r\nUse, duplication, or disclosure by the Government is subject to\r\nrestrictions as set forth in subparagraph (c) of the Commercial\r\nComputer Software - Restricted Rights clause at FAR sec. 52.227-19 and\r\nsubparagraph (c) (1) (ii) of the Rights in Technical Data and Computer\r\nSoftware clause at DFARS sec. 252.227-7013.\r\n\r\n            Cisco Systems, Inc.\r\n            170 West Tasman Drive\r\n            San Jose, California 95134-1706\r\n\r\nThis product contains cryptographic features and is subject to United\r\nStates and local country laws governing import, export, transfer and\r\nuse. Delivery of Cisco cryptographic products does not imply\r\nthird-party authority to import, export, distribute or use encryption.\r\nImporters, exporters, distributors and users are responsible for\r\ncompliance with U.S. and local country laws. By using this product you\r\nagree to comply with applicable laws and regulations. If you are unable\r\nto comply with U.S. and local laws, return this product immediately.\r\n\r\nA summary of U.S. laws governing Cisco cryptographic products may be found at:\r\nhttp://www.cisco.com/wwl/export/crypto/tool/stqrg.html\r\n--More-- "
```

I propose that the space between `\r\n` and `--More-- ` is made optional in order to support such cases.