### PR TITLE
[aruos] Treat "running in a degraded state" messages as an error

### DIFF
--- a/pkg/device/aruos/device.go
+++ b/pkg/device/aruos/device.go
@@ -9,9 +9,10 @@ import (
 const (
 	promptExpression = `(\r\n)?(?P<prompt>[\w\-():]+) ?# $`
 	errorExpression  = `(` +
-		`% (Parse error|Incomplete command)` + `|` +
-		`(^|\n)WriteFlash .+` + `|` +
-		`(^|\n).+: ?WriteApFlash unsuccessful.+` +
+		`% (Parse error|Incomplete command)` +
+		`|(^|\n)WriteFlash .+` +
+		`|(^|\n).+: ?WriteApFlash unsuccessful.+` +
+		`|(^|\n)(Write memory|Configuration) is not allowed when CLI is running in a degraded state.($|\r?\n)` +
 		`)`
 	passwordExpression      = `.*Password: $`
 	loginExpression         = `.*User: $`

--- a/pkg/device/aruos/device_test.go
+++ b/pkg/device/aruos/device_test.go
@@ -48,3 +48,11 @@ func TestWriteFlashFail(t *testing.T) {
 	}
 	testutils.ExprTester(t, cases, errorExpression)
 }
+
+func TestDegraded(t *testing.T) {
+	cases := [][]byte{
+		[]byte("Write memory is not allowed when CLI is running in a degraded state."),
+		[]byte("Configuration is not allowed when CLI is running in a degraded state."),
+	}
+	testutils.ExprTester(t, cases, errorExpression)
+}


### PR DESCRIPTION
`wr mem` messages `Write memory is not allowed when CLI is running in a degraded state.`
`conf t` messages `Configuration is not allowed when CLI is running in a degraded state.`
