### PR TITLE
fix: h3c recognize wrong parameter command errors

### DIFF
--- a/pkg/device/h3c/device.go
+++ b/pkg/device/h3c/device.go
@@ -19,7 +19,7 @@ const (
 	promptExpression   = `(\r\r?\n|^|\x00)(?P<prompt>((\(M\))?[<\[][\w\-/]+[>\]]|\[[~*]?[/\w\-.:]+\]))$`
 	errorExpression    = `(` +
 		`(\^\r\n)?( % )?Error:(?P<error>.+) at '\^' position\.` +
-		`|\r\n % (Unrecognized command|Too many parameters|Incomplete command) found at '\^' position\.` +
+		`|\r\n % (Unrecognized command|Too many parameters|Incomplete command|Wrong parameter) found at '\^' position\.` +
 		`)`
 	pagerExpression = `(?P<store>(\r\n|\n))?  ---- More ----$`
 )

--- a/pkg/device/h3c/device_test.go
+++ b/pkg/device/h3c/device_test.go
@@ -13,6 +13,7 @@ func TestDeviceErrors(t *testing.T) {
 		[]byte("\r\n % Unrecognized command found at '^' position."),
 		[]byte("\r\n % Too many parameters found at '^' position."),
 		[]byte("\r\n % Incomplete command found at '^' position."),
+		[]byte("\r\r\n % Wrong parameter found at '^' position."),
 	}
 	testutils.ExprTester(t, errorCases, errorExpression)
 }


### PR DESCRIPTION
Add support for detecting the H3C error response:

```text
% Wrong parameter found at '^' position.
```

Previously, this response was not matched by the H3C error expression. As a result, gnetcli could report a successful command status even though the device had rejected the command.
This was reproduced when H3C rejected an invalid prefix-list index.