### PR TITLE
fix:  ProxyJump connections when HostName is not set

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -227,6 +227,7 @@ func (m *Server) createStreamerSSH(cfg StreamerConfig, add func(op gtrace.Operat
 		if err != nil {
 			return nil, fmt.Errorf("unable to get host params for ssh tunnel to %s:%w", cfg.params.proxyJump, err)
 		}
+		jumpHostParams.host, jumpHostParams.port = m.makeConnectArg(cfg.params.proxyJump, jumpHostParams)
 
 		opts := []ssh.SSHTunnelOption{ssh.SSHTunnelWithLogger(cfg.logger)}
 		if len(jumpHostParams.controlPath) > 0 {
@@ -235,7 +236,6 @@ func (m *Server) createStreamerSSH(cfg StreamerConfig, add func(op gtrace.Operat
 		if jumpHostParams.port > 0 {
 			opts = append(opts, ssh.SSHTunnelWithPort(jumpHostParams.port))
 		}
-		connHost = cfg.params.host
 
 		tun := ssh.NewSSHTunnel(jumpHostParams.host, jumpHostParams.GetCredentials(), opts...)
 

--- a/pkg/server/server_integration_test.go
+++ b/pkg/server/server_integration_test.go
@@ -228,6 +228,58 @@ Host mock-proxy
 	require.Contains(t, string(res.GetOut()), "Cisco IOS Software")
 }
 
+func TestDevAuthSSHConfigProxyJumpUsesInventoryIPWithoutHostName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	sshPub, err := ssh.NewPublicKey(pub)
+	require.NoError(t, err)
+	agentSocket := startTestAgent(t, priv)
+
+	targetLn, targetPort := newSSHServerPort(t)
+	proxyLn, proxyPort := newSSHServerPort(t)
+	ctx := t.Context()
+
+	const targetUser = "target-user"
+	serveTestSwitch(t, ctx, targetLn, publicKeyAuthCallback(targetUser, sshPub))
+
+	const proxyUser = "proxy-user"
+	serveTestSwitch(t, ctx, proxyLn, publicKeyAuthCallback(proxyUser, sshPub))
+
+	cfg := serverConfigFromYAML(t, `
+dev_auth:
+  ssh_config: true
+`)
+	sshConfig := fmt.Sprintf(`
+Host mock-sw
+  Port %d
+  User %s
+  IdentityAgent %s
+  ProxyJump localhost
+
+Host localhost
+  Port %d
+  User %s
+  IdentityAgent %s
+  ForwardAgent yes
+`, targetPort, targetUser, agentSocket, proxyPort, proxyUser, agentSocket)
+
+	client := newGnetcliTestClient(t, cfg, sshConfig, zap.NewNop())
+	res, err := client.Exec(ctx, &pb.CMD{
+		Host: "mock-sw",
+		Cmd:  "show version",
+		HostParams: &pb.HostParams{
+			Ip:     "127.0.0.1",
+			Device: "cisco",
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, string(res.GetOut()), "Cisco IOS Software")
+}
+
 func publicKeyAuthCallback(user string, pubKey ssh.PublicKey) gswitch.AuthCallback {
 	return func(req gswitch.AuthRequest) error {
 		if req.Method != gswitch.AuthMethodPublicKey {


### PR DESCRIPTION
Fix SSH connections through `ProxyJump` when `HostName` is not explicitly set in the SSH config.

In this configuration, gnetcli should:

- use the inventory IP received in `HostParams` for the target device;
- use the `ProxyJump` hostname as a fallback address for the jump host.

When the target had an inventory IP but no explicit HostName, cfg.params.host was empty. This resulted in a connection attempt to :22.