### PR TITLE
devconf: register fortios/fortigate device type for server and cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The project consist of go-library, GRPC server and CLI tool. It is typically use
 * **Execute commands instead of just reading and writing.**
 * **Pager, questions and error handling are supported.**  
   Describe CLI interface in a few expressions and get full power of the project.
-* **The project supports several network vendors, including Huawei, Juniper, Cisco, and RouterOS.**
+* **The project supports several network vendors, including Huawei, Juniper, Cisco, FortiGate (FortiOS), and RouterOS.**
 * **Netconf is supported.**  
   Exec netconf in same manner as text command to simplify automation workflow.
 * **SSH tunneling is supported.**

--- a/docs/basic_usage_cli.md
+++ b/docs/basic_usage_cli.md
@@ -35,7 +35,7 @@ Usage of cli:
   -dev-conf string
     	Path to yaml with device types
   -devtype string
-    	Device type from dev-conf file or from predifined: juniper, huawei, cisco, nxos, pc, netconf
+    	Device type from dev-conf file or from predifined: juniper, huawei, h3c, arista, cisco, nxos, bcomos, pc, ros, netconf, aruos, eltex, asa, fortios, sitonica
   -hostname string
     	Hostname
   -json

--- a/pkg/devconf/devconf.go
+++ b/pkg/devconf/devconf.go
@@ -17,6 +17,7 @@ import (
 	"github.com/annetutil/gnetcli/pkg/device/bcomos"
 	"github.com/annetutil/gnetcli/pkg/device/cisco"
 	"github.com/annetutil/gnetcli/pkg/device/eltex"
+	"github.com/annetutil/gnetcli/pkg/device/fortios"
 	"github.com/annetutil/gnetcli/pkg/device/genericcli"
 	"github.com/annetutil/gnetcli/pkg/device/h3c"
 	"github.com/annetutil/gnetcli/pkg/device/huawei"
@@ -231,20 +232,22 @@ func InitDeviceMapping(logger *zap.Logger, deviceFilePath string) (map[string]fu
 
 func InitDefaultDeviceMapping(logger *zap.Logger) map[string]func(streamer.Connector) device.Device {
 	deviceMaps := map[string]func(streamer.Connector) device.Device{
-		"juniper":  GenericCLIWrapper(juniper.NewDevice, logger),
-		"huawei":   GenericCLIWrapper(huawei.NewDevice, logger),
-		"h3c":      GenericCLIWrapper(h3c.NewDevice, logger),
-		"arista":   GenericCLIWrapper(arista.NewDevice, logger),
-		"cisco":    GenericCLIWrapper(cisco.NewDevice, logger),
-		"nxos":     GenericCLIWrapper(nxos.NewDevice, logger),
-		"bcomos":   GenericCLIWrapper(bcomos.NewDevice, logger),
-		"pc":       pc.NewDevice,
-		"ros":      GenericCLIWrapper(ros.NewDevice, logger),
-		"netconf":  netconf.BindDeviceOpts(netconf.NewDevice, netconf.WithLogger(logger)),
-		"aruos":    GenericCLIWrapper(aruos.NewDevice, logger),
-		"eltex":    GenericCLIWrapper(eltex.NewDevice, logger),
-		"asa":      GenericCLIWrapper(asa.NewDevice, logger),
-		"sitonica": GenericCLIWrapper(h3c.NewDevice, logger),
+		"juniper":   GenericCLIWrapper(juniper.NewDevice, logger),
+		"huawei":    GenericCLIWrapper(huawei.NewDevice, logger),
+		"h3c":       GenericCLIWrapper(h3c.NewDevice, logger),
+		"arista":    GenericCLIWrapper(arista.NewDevice, logger),
+		"cisco":     GenericCLIWrapper(cisco.NewDevice, logger),
+		"nxos":      GenericCLIWrapper(nxos.NewDevice, logger),
+		"bcomos":    GenericCLIWrapper(bcomos.NewDevice, logger),
+		"pc":        pc.NewDevice,
+		"ros":       GenericCLIWrapper(ros.NewDevice, logger),
+		"netconf":   netconf.BindDeviceOpts(netconf.NewDevice, netconf.WithLogger(logger)),
+		"aruos":     GenericCLIWrapper(aruos.NewDevice, logger),
+		"eltex":     GenericCLIWrapper(eltex.NewDevice, logger),
+		"asa":       GenericCLIWrapper(asa.NewDevice, logger),
+		"fortios":   GenericCLIWrapper(fortios.NewDevice, logger),
+		"fortigate": GenericCLIWrapper(fortios.NewDevice, logger),
+		"sitonica":  GenericCLIWrapper(h3c.NewDevice, logger),
 	}
 	return deviceMaps
 }

--- a/pkg/device/fortios/device_mock_test.go
+++ b/pkg/device/fortios/device_mock_test.go
@@ -1,0 +1,94 @@
+package fortios
+
+import (
+	"testing"
+
+	"github.com/annetutil/gnetcli/pkg/device"
+	"github.com/annetutil/gnetcli/pkg/streamer"
+	m "github.com/annetutil/gnetcli/pkg/testutils/mock"
+)
+
+var (
+	fortiHello = []m.Action{
+		m.Send("Forti1 # "),
+		// autocommands
+		m.Expect("config system console\n"),
+		m.SendEcho("config system console\r\r\n"),
+		m.Send("\r\nForti1 (console) # "),
+		m.Expect("set output standard\n"),
+		m.SendEcho("set output standard\r\r\n"),
+		m.Send("\r\nForti1 (console) # "),
+		m.Expect("end\n"),
+		m.SendEcho("end\r\r\n"),
+		m.Send("\r\nForti1 # "),
+	}
+	fortiBye = []m.Action{
+		m.Send("Forti1 # "),
+		m.Close(),
+	}
+)
+
+func TestFortiOS(t *testing.T) {
+	testCases := []struct {
+		name    string
+		command string
+		result  string
+		dialog  [][]m.Action
+	}{
+		{
+			name:    "get system status",
+			command: "get system status",
+			result:  "Version: FortiGate-60F v7.2.5,build1517,230504 (GA.F)\nHostname: Forti1\n\n",
+			dialog: [][]m.Action{
+				fortiHello,
+				{
+					m.Expect("get system status\n"),
+					m.SendEcho("get system status\r\r\n"),
+					m.Send("Version: FortiGate-60F v7.2.5,build1517,230504 (GA.F)\r\nHostname: Forti1\r\n\r\n"),
+				},
+				fortiBye,
+			},
+		},
+		{
+			name:    "vdom prompt",
+			command: "config vdom",
+			result:  "\n",
+			dialog: [][]m.Action{
+				fortiHello,
+				{
+					m.Expect("config vdom\n"),
+					m.SendEcho("config vdom\r\r\n"),
+					m.Send("\r\nForti1 (vdom) # "),
+				},
+				{m.Close()},
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			actions := m.ConcatMultipleSlices(tc.dialog)
+			m.RunDialogWithDefaultCreds(t, func(connector streamer.Connector) device.Device {
+				dev := NewDevice(connector)
+				return &dev
+			}, actions, tc.command, tc.result)
+		})
+	}
+}
+
+func TestFortiOSError(t *testing.T) {
+	dialog := m.ConcatMultipleSlices([][]m.Action{
+		fortiHello,
+		{
+			m.Expect("reboot\n"),
+			m.SendEcho("reboot\r\r\n"),
+			m.Send("command parse error before 'reboot'\r\nCommand fail. Return code -61\r\n\r\n"),
+		},
+		fortiBye,
+	})
+	m.RunInvalidDialog(t, func(connector streamer.Connector) device.Device {
+		dev := NewDevice(connector)
+		return &dev
+	}, dialog, "reboot")
+}


### PR DESCRIPTION
## Summary

`gnetcli_server` and `cli` could not work with FortiGate devices: the FortiOS implementation in `pkg/device/fortios` existed but was never registered in `devconf.InitDefaultDeviceMapping`, so any request with `device: fortios` failed with `unknown device`.

Changes:
- `pkg/devconf/devconf.go`: register `fortios` (plus `fortigate` alias) in the default device mapping.
- `pkg/device/fortios/device_mock_test.go`: mock SSH dialog tests — auto commands on connect, FortiOS echo (`cmd\r\r\n`), context prompt `host (vdom) # `, error parsing (`Command fail. Return code -61` → `status=1`).
- Docs: actual list of predefined device types in `docs/basic_usage_cli.md`, FortiGate mentioned in README.

No changes to the FortiOS regexes or to other devices.

## Testing

### Unit
`go test ./...` — green (new tests: `TestFortiOS`, `TestFortiOSError`).

### Real hardware
Two devices, each command executed both directly through `cli` and through `gnetcli_server` (HTTP gateway `/api/v1/exec`, `trace: true`). Hostnames, IPs, serials and credentials are redacted.

| Device | Firmware |
|---|---|
| FortiGate-100F | v6.4.2,build1723 (GA) |
| FortiGate-200G | v7.2.11,build6561 (GA.M) |

Results are identical on both versions:

| Command | cli | server | Notes |
|---|---|---|---|
| `get system status` | status=0 | status=0 | full output, prompt detected |
| `get system performance status` | status=0 | status=0 | |
| `show system interface` | status=0 | status=0 | 5.5 KB (v6) / 11.8 KB (v7), no pager prompt |
| `get system foo` | status=1 | status=1 | `error="command parse error before 'foo'\nCommand fail. Return code -61"` |
| `diagnose sys session stat` | status=0 | status=0 | |
| `config system global` | status=0 | status=0 | prompt changes to `host (global) # ` |
| `end` (top level, fresh session) | status=1 | status=1 | device error `Unknown action 0` — expected, correctly parsed |
| session: `get system status` → `config system global` → `end` → `get system status` | all status=0 | — | one SSH connection |

Per-command latency 0.2–0.5 s, no warnings/errors in the server log.

Server trace of the connect phase and an invalid command (FortiOS 7, same on 6):

```
R 'fgt # '
W 'config system console\n'
R 'config system console\r\r\n\r\nfgt (console) # '
W 'set output standard\n'
R 'set output standard\r\r\n\r\nfgt (console) # '
W 'end\n'
R 'end\r\r\n\r\nfgt # '
W 'get system foo\n'
R "get system foo\r\r\n\r\ncommand parse error before 'foo'\r\nCommand fail. Return code -61\r\n\r\nfgt # "
-> status: 1, error_str: "command parse error before 'foo'\nCommand fail. Return code -61"
```

Example request:

```sh
curl -s -X POST http://127.0.0.1:50052/api/v1/exec -H 'Content-Type: application/json' -d '{
  "host": "<fortigate>", "cmd": "get system status", "string_result": true,
  "host_params": {"device": "fortios", "credentials": {"login": "<login>", "password": "<password>"}}
}'
```

## Known cosmetic point (not addressed here)
For commands without output (`config ...`, `end`) `out` is `"\n"` rather than empty, because the device sends an extra `\r\n` between the echo and the prompt. Could be handled by extending the echo expression in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
