### PR TITLE
juniper: accept prompt at start of stream

### DIFF
--- a/pkg/device/juniper/device.go
+++ b/pkg/device/juniper/device.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	promptExpression = `(\r\n({master}\[edit\]|{master}|{master:\d}|\[edit\]))?\r\n(?P<prompt>[\w\-.]+@[\w\-.]+[>#]) $`
+	promptExpression = `(\r\n({master}\[edit\]|{master}|{master:\d}|\[edit\]))?(\r\n|^)(?P<prompt>[\w\-.]+@[\w\-.]+[>#]) $`
 	errorExpression  = `(\n|^)(syntax error\.|syntax error, expecting <command>.|unknown command\.|error: (configuration check-out failed|configuration database modified|commit failed: \([\w ]+\))|configure exclusive error: .+)\r\n`
 	pagerExpression  = `\n---\(more( \d+%)?\)---$`
 )

--- a/pkg/device/juniper/device_test.go
+++ b/pkg/device/juniper/device_test.go
@@ -13,6 +13,7 @@ func TestPrompt(t *testing.T) {
 		[]byte("\r\n{master}\r\nloginlog@xdc-13f3> "),
 		[]byte("\r\n[edit]\r\nlogin-login@host-dc-1d# "),
 		[]byte("\r\n{master}[edit]\r\nlogin-login@hosth# "),
+		[]byte("login-name@router-name> "),
 	}
 	testutils.ExprTester(t, cases, promptExpression)
 }


### PR DESCRIPTION
Juniper cRPD may return the initial CLI prompt as the first bytes of the SSH shell output,
without a preceding CRLF.

The existing Juniper prompt expression requires `\r\n` before the prompt.
As a result, gnetcli does not recognize an already received prompt and eventually fails with a read timeout.